### PR TITLE
Read environment var for max body size

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ if (process.env.NO_DATA) {
 
 tiles = new TileSet(tileDirectory, {downloader:tileDownloader});
 
-app.use(bodyParser.json());
+var maxPostSize = "500kb";
+if (process.env.MAX_POST_SIZE) {
+    maxPostSize = process.env.MAX_POST_SIZE;
+}
+
+app.use(bodyParser.json({limit: maxPostSize}));
 app.use(function(req, res, next) {
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');


### PR DESCRIPTION
Im not sure what the default max body size is, but it seems to be around 250kb, which was to small for some of the geometries im using, so I made it configureable, with a default of 500kb 
